### PR TITLE
Remove dependency on javafx for usage on JDK 11+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,65 @@
+## Gradle
+.gradle
+gradle-app.setting
+build/
+
+## Java:
+*.class
+*.war
+*.ear
+hs_err_pid*
+
+## Android:
+android/libs/armeabi/
+android/libs/armeabi-v7a/
+android/libs/x86/
+android/gen/
+local.properties
+com_crashlytics_export_strings.xml
+
+## GWT:
+war/
+html/war/gwt_bree/
+html/gwt-unitCache/
+.apt_generated/
+html/war/WEB-INF/deploy/
+html/war/WEB-INF/classes/
+.gwt/
+gwt-unitCache/
+www-test/
+.gwt-tmp/
+
+## IntelliJ, Android Studio:
+.idea/
+*.ipr
+*.iws
+*.iml
+out/
+
+## Eclipse
+.classpath
+.project
+.metadata
+**/bin/
+tmp/
+*.tmp
+*.bak
+*.swp
+*~.nib
+.settings/
+.loadpath
+.externalToolBuilders/
+*.launch
+
+## NetBeans
+**/nbproject/private/
+build/
+nbbuild/
+dist/
+nbdist/
+nbactions.xml
+nb-configuration.xml
+
+## OS Specific
+.DS_Store
+/target/

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>net.fbridault.eeel</groupId>
     <artifactId>artemis-odb-eeel</artifactId>
-    <version>1.2.1</version>
+    <version>1.2.2-SNAPSHOT</version>
     <packaging>jar</packaging>
     <description>Drop-in Extension for artemis-odb. Annotation bases entity event listeners</description>
     <url>https://github.com/GMWolf/artemis-odb-eeel</url>

--- a/src/main/java/net/fbridault/eeel/EEELEventSystem.java
+++ b/src/main/java/net/fbridault/eeel/EEELEventSystem.java
@@ -1,14 +1,14 @@
 package net.fbridault.eeel;
 
-import com.artemis.Aspect;
-import com.artemis.BaseSystem;
-import javafx.util.Pair;
-
-import java.lang.reflect.ParameterizedType;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import com.artemis.Aspect;
+import com.artemis.BaseSystem;
+
+import net.fbridault.eeel.util.Pair;
 
 public class EEELEventSystem extends BaseSystem {
 

--- a/src/main/java/net/fbridault/eeel/util/Pair.java
+++ b/src/main/java/net/fbridault/eeel/util/Pair.java
@@ -1,0 +1,73 @@
+package net.fbridault.eeel.util;
+
+import java.io.Serializable;
+
+/**
+ * Simple key-value pair.
+ * 
+ * @author Ken Schosinsky
+ */
+public class Pair<K, V> implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private K key;
+    private V value;
+
+    public Pair(K key, V value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    public K getKey() {
+        return key;
+    }
+
+    public void setKey(K key) {
+        this.key = key;
+    }
+
+    public V getValue() {
+        return value;
+    }
+
+    public void setValue(V value) {
+        this.value = value;
+    }
+
+    @Override
+    public String toString() {
+        return "Pair [key=" + key + ", value=" + value + "]";
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((key == null) ? 0 : key.hashCode());
+        result = prime * result + ((value == null) ? 0 : value.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        Pair other = (Pair) obj;
+        if (key == null) {
+            if (other.key != null)
+                return false;
+        } else if (!key.equals(other.key))
+            return false;
+        if (value == null) {
+            if (other.value != null)
+                return false;
+        } else if (!value.equals(other.value))
+            return false;
+        return true;
+    }
+
+}


### PR DESCRIPTION
With JDK 11 javafx was removed from the JDK. Using this library on JDK 11+ requires adding JavaFX to the classpath.

This PR replaces the usage of javafx.util.Pair with its own implementation so JavaFX isn't required anymore.